### PR TITLE
fix: avoid treating double-dash as a param

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,16 +24,18 @@ const removeFileIfExist = (pathToDelete) => {
   }
 };
 
-async function executeNodeFile(outFile) {
-  let parentArgs;
-  if (process.argv.includes("-w") || process.argv.includes("--watch")) {
-    parentArgs = process.argv.slice(3, process.argv.indexOf("-w"));
-  } else {
-    parentArgs = process.argv.slice(3);
-  }
+function paramsForChild(args) {
+  if (args.includes('--'))
+      return args.slice(args.indexOf('--') + 1)
+  else if (args.includes('-w') || args.includes('--watch'))
+      return args.slice(Math.max(args.indexOf('-w'), args.indexOf('--watch')) + 2)
+  return []
+}
 
+async function executeNodeFile(outFile) {
+  const args = paramsForChild(process.argv);  
   return new Promise((resolve, reject) => {
-    const child = spawn("node", [outFile, ...parentArgs], {
+    const child = spawn("node", [outFile, ...args], {
       cwd: process.cwd(),
       stdio: "inherit",
     });


### PR DESCRIPTION
Hi again :)

I needed to pass params to my app like a `target` arg for exemple : `ts-run my-app.ts --target=foobar`

But I got the error `error: unknown option '--target=foobar'`, here `ts-run` is right, `target` is not a known arg

So I used the standard way to give params to the child, via double dash : `ts-run my-app.ts -- --target=foobar`

But the double dash was also transmitted to child, I added this filter to prevent this

Let me know if it's ok or if you have a better suggestion 

Regards